### PR TITLE
Indicate layer is also compatible with rocko

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "meta-intel-media-stack"
 BBFILE_PATTERN_meta-intel-media-stack = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-intel-media-stack = "6"
 
-LAYERSERIES_COMPAT_meta-intel-media-stack = "sumo"
+LAYERSERIES_COMPAT_meta-intel-media-stack = "sumo rocko"
 
 LINUX_MEDIA_SERVER_STUDIO_LOCATION = "https://github.com/pauldotknopf/meta-intel-media-stack/releases/download/2017_R3/intel-linux-media_generic_16.5.2-64009_64bit.tar.gz"
 


### PR DESCRIPTION
According to the discussion on issue #3 there shouldn't be any reason to not support rocko. This fixes the incompatibility error with rocko.